### PR TITLE
RRD - Add Lean 4 export utility for Conjecture names with auto-detected variables

### DIFF
--- a/tests/test_lean_export.py
+++ b/tests/test_lean_export.py
@@ -1,0 +1,41 @@
+import pandas as pd
+import pytest
+
+from txgraffiti2.lean_export import conjecture_to_lean
+
+# Dummy Conjecture with .name only, to avoid full dependency in the test
+class DummyConj:
+    def __init__(self, name): self.name = name
+
+@pytest.fixture
+def df():
+    return pd.DataFrame(
+        {
+            "degree":   [3, 4],
+            "order":    [10, 12],
+            "connected": [True, False],
+            "zero_forcing_number": [4, 5],
+            # 'name' column is intentionally included and must be skipped
+            "name": ["G1", "G2"],
+        }
+    )
+
+def test_basic_implication(df):
+    conj = DummyConj("degree ≥ 3 → zero_forcing_number ≤ order / 2")
+    lean = conjecture_to_lean(conj, df)
+    assert lean == (
+        "∀ G : SimpleGraph V, degree G ≥ 3 → zero_forcing_number G ≤ order G / 2"
+    )
+
+def test_and_or_not(df):
+    conj = DummyConj("(connected) ∧ (degree ≥ 3) → ¬(zero_forcing_number > order)")
+    lean = conjecture_to_lean(conj, df)
+    assert lean == (
+        "∀ G : SimpleGraph V, (connected G) ∧ (degree G ≥ 3) → ¬(zero_forcing_number G > order G)"
+    )
+
+def test_theorem_wrapper(df):
+    conj = DummyConj("degree ≥ 2 → connected")
+    lean = conjecture_to_lean(conj, df, theorem_name="deg_two_connected")
+    assert lean.startswith("theorem deg_two_connected :")
+    assert "degree G ≥ 2 → connected G" in lean

--- a/txgraffiti2/__init__.py
+++ b/txgraffiti2/__init__.py
@@ -1,2 +1,3 @@
 from txgraffiti2.conjecture_logic import *  # noqa: F401,F403
 from txgraffiti2.hull_generators import *  # noqa: F401,F403
+from txgraffiti2.lean_export import *  # noqa: F401,F403

--- a/txgraffiti2/lean_export.py
+++ b/txgraffiti2/lean_export.py
@@ -1,0 +1,112 @@
+"""
+lean_export.py
+==============
+
+Tools for turning Conjecture names into Lean-4 propositions.
+
+Key public entry points
+-----------------------
+conjecture_to_lean(conj, df, *, theorem_name=None) -> str
+    Translate Conjecture *conj* into a Lean statement, using *df* to discover
+    which variable names exist.  If *theorem_name* is given, wrap it in a
+    `theorem ... :` block with a final `:= sorry`.
+
+auto_var_map(df, *, skip=("name",)) -> dict[str, str]
+    Build the {python_name: lean_name} map automatically from the columns of
+    *df*.  Numeric or Boolean – doesn’t matter.
+"""
+
+from __future__ import annotations
+import re
+from collections.abc import Mapping
+import pandas as pd
+from typing import Any
+
+from txgraffiti2.conjecture_logic import Conjecture
+
+__all__ = [
+    "conjecture_to_lean",
+    "auto_var_map",
+    "LEAN_SYMBOLS",
+    "LEAN_SYMBOLS",
+]
+
+# ---------------------------------------------------------------------------
+# 1. Lean-friendly replacements for operators & symbols
+# ---------------------------------------------------------------------------
+LEAN_SYMBOLS: Mapping[str, str] = {
+    "∧": "∧",
+    "∨": "∨",
+    "¬": "¬",
+    "→": "→",
+    "≥": "≥",
+    "<=": "≤",
+    ">=": "≥",
+    "==": "=",
+    "=": "=",
+    "!=": "≠",
+    "<": "<",
+    ">": ">",
+    "/": "/",
+    "**": "^",
+}
+
+# ---------------------------------------------------------------------------
+# 2. Automatic variable-map builder
+# ---------------------------------------------------------------------------
+def auto_var_map(df: pd.DataFrame, *, skip: tuple[str, ...] = ("name",)) -> dict[str, str]:
+    """
+    Build a mapping  {column_name -> "column_name G"}   (for Lean)
+    while skipping columns in *skip* (default: "name").
+    """
+    return {c: f"{c} G" for c in df.columns if c not in skip}
+
+
+# ---------------------------------------------------------------------------
+# 3. The main translator
+# ---------------------------------------------------------------------------
+def _translate(expr: str, var_map: Mapping[str, str]) -> str:
+    # 3a. longest variable names first so 'order' doesn't clobber 'total_order'
+    for var in sorted(var_map, key=len, reverse=True):
+        expr = re.sub(rf"\b{re.escape(var)}\b", var_map[var], expr)
+
+    # 3b. symbolic replacements (do ** after >= / <= replacements)
+    for sym, lean_sym in LEAN_SYMBOLS.items():
+        expr = expr.replace(sym, lean_sym)
+
+    # tidy whitespace
+    expr = re.sub(r"\s+", " ", expr).strip()
+    return expr
+
+
+def conjecture_to_lean(
+    conj: "Conjecture | str",           # accepts object or raw string
+    df: pd.DataFrame,
+    *,
+    theorem_name: str | None = None,
+    extra_var_map: Mapping[str, str] | None = None,
+) -> str:
+    """
+    Parameters
+    ----------
+    conj : Conjecture | str
+        Either a Conjecture instance or a raw name string to translate.
+    df : pandas.DataFrame
+        DataFrame whose columns define which variables exist.
+    theorem_name : str, optional
+        If provided, wrap the result in a `theorem … :` Lean block.
+    extra_var_map : dict, optional
+        Add/override variable translations.
+
+    Returns
+    -------
+    str : Lean 4 proposition (or theorem block).
+    """
+    name_str = conj.name if hasattr(conj, "name") else str(conj)
+    var_map = {**auto_var_map(df), **(extra_var_map or {})}
+    proposition = _translate(name_str, var_map)
+    proposition = f"∀ G : SimpleGraph V, {proposition}"
+
+    if theorem_name:
+        proposition = f"theorem {theorem_name} : {proposition} := by\n  -- sketch proof\n  sorry"
+    return proposition


### PR DESCRIPTION
### ✨ Overview

This PR adds functionality to export `Conjecture` objects into Lean 4-compatible logical statements, based solely on the `.name` string and the structure of the associated `pandas.DataFrame`.

---

### 🔧 Features

- **`conjecture_to_lean`**  
  Translates a `Conjecture` (or string) into a Lean proposition of the form:  
  ```lean
  ∀ G : SimpleGraph V, ...
  ```

- **Automatic variable detection**  
  Column names from the `DataFrame` are mapped to `"<column> G"` in Lean syntax. The `"name"` column is excluded by default.

- **Custom variable mapping**  
  Optional `extra_var_map` allows overriding or extending default variable substitutions.

- **Optional theorem wrapping**  
  Pass `theorem_name="..."` to wrap the output in a Lean `theorem` declaration:
  ```lean
  theorem my_conjecture : ∀ G : SimpleGraph V, ... := sorry
  ```

- **Robust symbol replacements**  
  Converts common logic and comparison symbols:
  - `∧`, `∨`, `¬`, `→`
  - `≥`, `≤`, `≠`, `==`, `**`  
  - Normalizes whitespace and preserves parenthesis structure

---

### 🧪 Testing

Unit tests included (`pytest`):
- Ensures variable names are correctly substituted from the DataFrame
- Verifies logic symbol translation
- Confirms that `"name"` column is ignored
- Tests optional `theorem` wrapping behavior

---

### 📦 Motivation

This utility enables symbolic conjectures to be easily exported into Lean 4, supporting downstream workflows such as:
- Generating `.lean` files for verification or proof search
- Integrating with AI theorem-proving pipelines
- Logging formal statements for benchmarking and documentation


### ⚠️ Manual Verification Recommended

While the Lean translation utility provides best-effort conversion from symbolic conjecture names, we recommend **manually reviewing** the generated Lean statements for correctness, especially for:
- Unusual variable names
- Ambiguous or nested logic
- Assumptions about graph types or domains

This utility assumes consistent naming conventions and will not catch semantic errors in interpretation.
