### PR TITLE
JNE - changed the accuracy score to only consider instances which satisfy the hypothesis

### DIFF
--- a/txgraffiti2/conjecture_logic.py
+++ b/txgraffiti2/conjecture_logic.py
@@ -386,8 +386,12 @@ class Conjecture(Predicate):
         return bool(self(df).all())
 
     def accuracy(self, df: pd.DataFrame) -> float:
-        return float(self(df).mean())
-
+        hyp_true = self.hypothesis(df)
+        if not hyp_true.any():
+            return float(0.0)
+        valid = self(df)[hyp_true]
+        return float(valid.mean())
+    
     def counterexamples(self, df: pd.DataFrame) -> pd.DataFrame:
         return df[~self(df)]
 


### PR DESCRIPTION
Previously, the accuracy score was out of the total dataset. This could skew the score of a conjecture to seem inaccurate or untrue, when in reality the explanation is that its hypothesis is satisfied on few instances. Now, it reflects the proportion of truth only on instances which satisfy its hypothesis. If no instances satisfy the hypothesis, the conjecture receives an accuracy of 0. 

Feel free to change it back if you disagree!! 