### PR TITLE
Add morgan and dalmatian as post processing filters

### DIFF
--- a/tests/unit/processing/test_dalmatian_filter.py
+++ b/tests/unit/processing/test_dalmatian_filter.py
@@ -1,0 +1,34 @@
+from txgraffiti.logic import *
+from txgraffiti.processing import filter_with_dalmatian
+import pandas as pd
+
+
+def test_filter_with_dalmatian_basic():
+    df = pd.DataFrame({
+        'alpha':     [1, 2, 3],
+        'beta':      [2, 3, 4],
+        'connected': [True, True, True],
+    })
+
+    P = Predicate('connected', lambda df: df['connected'])
+    A = Property('alpha', lambda df: df['alpha'])
+    B = Property('beta',  lambda df: df['beta'])
+
+    c1 = P >> (A <= B + 3)   # Loose
+    c2 = P >> (A <= B + 1)   # Tighter
+    c3 = P >> (A <= B)       # Best
+
+    c4 = P >> (B <= 4) # Noncomparible to c1, c2, and c3
+    c5 = P >> (B <= 5) # Comparible to c4, but worse
+    c6 = P >> (B <= 3) # Comparible to, and better than c4, but false
+
+    # Only c2 and c3 should remain
+    accepted = filter_with_dalmatian([c1, c2, c3, c4, c5], df)
+
+    assert c3 in accepted
+    assert c2 not in accepted
+    assert c1 not in accepted
+
+    assert c4 in accepted
+    assert c5 not in accepted
+    assert c6 not in accepted

--- a/tests/unit/processing/test_davila_filter.py
+++ b/tests/unit/processing/test_davila_filter.py
@@ -1,0 +1,35 @@
+import pandas as pd
+from txgraffiti.logic import Predicate, Property, Conjecture
+from txgraffiti.processing.davila import filter_with_morgan
+
+def test_filter_with_morgan_basic():
+    # Create test DataFrame
+    df = pd.DataFrame({
+        'alpha':     [1, 2, 3],
+        'beta':      [3, 2, 1],
+        'connected': [True, True, True],
+        'tree':      [False, True, False],
+    })
+
+    # Define predicates and properties
+    P_conn = Predicate('connected', lambda df: df['connected'])
+    P_tree = Predicate('tree',      lambda df: df['tree'])
+
+    A = Property('alpha', lambda df: df['alpha'])
+    B = Property('beta',  lambda df: df['beta'])
+
+    # Conjecture 1: more specific
+    c1 = P_tree >> (A <= B)
+    # Conjecture 2: more general, same conclusion
+    c2 = P_conn >> (A <= B)
+
+    # Conjecture 3: different conclusion, should not be removed
+    c3 = P_tree >> (A >= B)
+
+    # Apply Morgan filtering
+    accepted = filter_with_morgan([c1, c2, c3], df)
+
+    # Only c2 and c3 should be retained
+    assert c2 in accepted
+    assert c3 in accepted
+    assert c1 not in accepted

--- a/txgraffiti/processing/__init__.py
+++ b/txgraffiti/processing/__init__.py
@@ -1,3 +1,5 @@
 
 from txgraffiti.processing.registry import *
 from txgraffiti.processing.postprocessors import *
+from txgraffiti.processing.davila import *
+from txgraffiti.processing.fajtlowicz import *

--- a/txgraffiti/processing/davila.py
+++ b/txgraffiti/processing/davila.py
@@ -1,0 +1,36 @@
+from txgraffiti.logic import *
+from txgraffiti.heuristics import same_conclusion, is_strict_subset
+from typing import List, Union
+import pandas as pd
+
+__all__ = [
+    'filter_with_morgan'
+]
+
+def filter_with_morgan(
+    candidates: list[Conjecture],
+    df: pd.DataFrame,
+) -> list[Conjecture]:
+    """
+    Apply the Morgan heuristic to a list of conjectures, removing those
+    that are strictly less general than another with the same conclusion.
+    """
+    accepted: list[Conjecture] = []
+
+    for new_conj in candidates:
+        keep = True
+        new_mask = new_conj.hypothesis(df)
+        for old_conj in accepted[:]:
+            if same_conclusion(old_conj, new_conj):
+                old_mask = old_conj.hypothesis(df)
+                if is_strict_subset(new_mask, old_mask):
+                    # new is more specific → reject new
+                    keep = False
+                    break
+                elif is_strict_subset(old_mask, new_mask):
+                    # old is more specific → remove old
+                    accepted.remove(old_conj)
+        if keep:
+            accepted.append(new_conj)
+
+    return accepted

--- a/txgraffiti/processing/fajtlowicz.py
+++ b/txgraffiti/processing/fajtlowicz.py
@@ -1,0 +1,40 @@
+from txgraffiti.logic import *
+from txgraffiti.heuristics import dalmatian_accept
+from typing import List, Union
+import pandas as pd
+
+__all__ = [
+    'filter_with_dalmatian',
+]
+
+def filter_with_dalmatian(conjectures, df):
+    """
+    Apply the Dalmatian heuristic to a list of conjectures, retaining only those
+    that are strictly tighter than all other matching conjectures on at least one row.
+
+    Parameters
+    ----------
+    conjectures : list of Conjecture
+        Candidate conjectures to evaluate.
+    df : pd.DataFrame or KnowledgeTable
+        Data used for truth and tightness checks.
+
+    Returns
+    -------
+    list of Conjecture
+        The accepted conjectures.
+    """
+    accepted = []
+
+    for new_conj in conjectures:
+        if not isinstance(new_conj.conclusion, Inequality):
+            continue  # skip non-inequality conclusions
+
+        # Compare against all other conjectures (not itself)
+        others = [c for c in conjectures if c != new_conj]
+
+        if dalmatian_accept(new_conj, others, df):
+            accepted.append(new_conj)
+
+    return accepted
+


### PR DESCRIPTION
# 🧩 Purpose of this Pull Request

As noted in a previous discussion, applying the heuristics as acceptance criteria still allows non-desirable conjectures to be omitted into the list of conjectures presented to the user. This patch adds new functions for applying the Morgan heuristic and the Dalmatian heuristic post conjecture list construction. 

---

## ✅ Summary of Changes



- [x] **New functionality**
      

- [ ] **Bug fix**
     

- [ ] **Documentation**
      

- [x] **Testing and CI**
      Small unit tests have been added. This need to be checked for accuracy by the reviewer. 

---

## 🧪 Testing Instructions

Run the following command to execute all tests. 

```bash
# Example
pytest 
```



---

## 📎 Related Issues or Context

N/A 

---

### 📌 Notes for Reviewers

None
