### PR TITLE
JNE - added a unit test for the Morgan heuristic for incomparable hypotheses

### DIFF
--- a/tests/unit/processing/test_davila_filter.py
+++ b/tests/unit/processing/test_davila_filter.py
@@ -33,3 +33,26 @@ def test_filter_with_morgan_basic():
     assert c2 in accepted
     assert c3 in accepted
     assert c1 not in accepted
+
+def test_incomparable_hypotheses():
+    df = pd.DataFrame({
+        'alpha':     [1, 2, 3],
+        'beta':      [2, 3, 4],
+        'triangle_free': [True, True, False],
+        'regular':   [True, False, True],
+    })
+
+    P = Predicate('triangle_free', lambda df: df['triangle_free'])
+    Q = Predicate('regular', lambda df: df['regular'])
+    A = Property('alpha', lambda df: df['alpha'])
+    B = Property('beta',  lambda df: df['beta'])
+    
+    # c1 and c2 are incomparable hypotheses, and have the same conclusion
+    c1 = P >> (A < B)
+    c2 = Q >> (A < B)
+    
+    accepted = filter_with_morgan([c1, c2], df)
+    
+    assert c1 in accepted
+    assert c2 in accepted
+    


### PR DESCRIPTION
…ptheses

# 🧩 Purpose of this Pull Request

Added a unit test for the Morgan heuristic which tests acceptance of two conjectures with different hypotheses (that do not contain one another) and the same conclusion.

---

## ✅ Summary of Changes

Please check and describe what applies:

- [ ] **New functionality**
      _Short description of feature, e.g., added new generator, predicate logic enhancement…_

- [ ] **Bug fix**
      _Details about resolved issues or incorrect behavior…_

- [ ] **Documentation**
      _Updated README, Sphinx docs, docstrings, or examples…_

- [x ] **Testing and CI**
      _Integration test added, pytest improvement, GitHub Actions config change…_

---

## 🧪 Testing Instructions

pytests should pass!

### 📌 Notes for Reviewers

can add more tests in the future, suggestions welcome.
